### PR TITLE
ダイスロール処理落ち対策

### DIFF
--- a/cogs/cautoreply.py
+++ b/cogs/cautoreply.py
@@ -136,6 +136,7 @@ class CAutoreply(commands.Cog):
             elif message.content.startswith("oruvanoruvan"):
                 await message.channel.send(ORUVANORUVAN, silent=True)
 
+            result = None
             try:
                 result = parse_and_evaluate(message.content)
             except ValueError:


### PR DESCRIPTION
ダイスの数が100より大きい、または面数が10000以上の場合は処理させないことにしました（このオーダーならどんな低スペックなPCでも処理できるでしょう）