### PR TITLE
新生ダイスコマンド・いくつかのコマンドへのレート制限

### DIFF
--- a/cogs/cautoreply.py
+++ b/cogs/cautoreply.py
@@ -28,59 +28,6 @@ GABU = """
 　（＿フ彡　　　　　 　　/　←>>1
 """
 
-
-# ダイスロール判定関数
-def parse_and_evaluate(expression: str):
-    expression = expression.replace(" ", "")
-
-    def evaluate_dice_expression(expr: str):
-        tokens = expr.split('+')
-        total = 0
-        breakdown = []
-
-        for token in tokens:
-            token = token.strip().lower()
-            if 'd' in token:
-                num, sides = token.split('d')
-                num = int(num) if num else 1
-                sides = int(sides)
-                if num > 100 or sides > 10000:
-                    raise ValueError                
-                rolls = [random.randint(1, sides) for _ in range(num)]
-                total += sum(rolls)
-                breakdown.append(f"{rolls}")
-            else:
-                val = int(token)
-                total += val
-                breakdown.append(str(val))
-
-        return total, breakdown
-
-    # 不等式を検出
-    match = re.match(r'(.+?)(<=|>=|==|!=|<|>)(.+)', expression)
-    if match:
-        dice_expr, operator, target = match.groups()
-        target = int(target)
-        total, breakdown = evaluate_dice_expression(dice_expr)
-        comparison_result = eval(f"{total} {operator} {target}")
-        return {
-            'type': 'comparison',
-            'success': comparison_result,
-            'result': total,
-            'breakdown': breakdown,
-            'operator': operator,
-            'target': target
-        }
-    else:
-        # 不等式がない → 単なるダイスロール
-        total, breakdown = evaluate_dice_expression(expression)
-        return {
-            'type': 'roll',
-            'result': total,
-            'breakdown': breakdown
-        }
-
-
 class CAutoreply(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
@@ -135,21 +82,6 @@ class CAutoreply(commands.Cog):
 
             elif message.content.startswith("oruvanoruvan"):
                 await message.channel.send(ORUVANORUVAN, silent=True)
-
-            result = None
-            try:
-                result = parse_and_evaluate(message.content)
-            except ValueError:
-                pass  # ダイスロールでなかった or あまりにもデカい数が入力された
-            result["breakdown"] = map(lambda x: x.replace(" ", ""), result["breakdown"])
-            embed = discord.Embed()
-            if result["type"] == "roll":  # 成否判定なし
-                embed.color = 0x808080
-                embed.description = f"{"+".join(result["breakdown"])} = {result["result"]}"
-            if result["type"] == "comparison":  # 成否判定あり
-                embed.color = 0x456cba if result["success"] else 0xba4545
-                embed.description = f"{"+".join(result["breakdown"])} = {result["result"]} {result["operator"]} {result["target"]} : {"成功" if result["success"] else "失敗"}"
-            await message.reply(embed=embed, silent=True)
 
 
 async def setup(bot: commands.Bot):

--- a/cogs/ccolor.py
+++ b/cogs/ccolor.py
@@ -94,6 +94,7 @@ class CColor(app_commands.Group):
             )
 
     @app_commands.command(name="random", description="カラーコードをランダムに出力し行います")
+    @app_commands.checks.cooldown(2, 5)
     async def random(self, interaction: discord.Interaction):
         try:
             color = "#" + randhex()[2:].zfill(2) + randhex()[2:].zfill(2) + randhex()[2:].zfill(2)
@@ -120,6 +121,10 @@ class CColor(app_commands.Group):
             await interaction.response.send_message(
                 embed=create_embed("エラー", "値が無効です"), ephemeral=True
             )
+
+    async def on_error(self, interaction: discord.Interaction, error: app_commands.AppCommandError):
+       if isinstance(error, app_commands.CommandOnCooldown):
+           await interaction.response.send_message("ちょっと待って！", ephemeral=True)
 
 
 async def setup(bot: commands.Bot):

--- a/cogs/ccolor.py
+++ b/cogs/ccolor.py
@@ -94,7 +94,7 @@ class CColor(app_commands.Group):
             )
 
     @app_commands.command(name="random", description="カラーコードをランダムに出力し行います")
-    @app_commands.checks.cooldown(2, 5)
+    @app_commands.checks.cooldown(1, 3)
     async def random(self, interaction: discord.Interaction):
         try:
             color = "#" + randhex()[2:].zfill(2) + randhex()[2:].zfill(2) + randhex()[2:].zfill(2)

--- a/cogs/cdice.py
+++ b/cogs/cdice.py
@@ -1,0 +1,85 @@
+import io
+import random
+import struct
+import zlib
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from utils.util import create_codeblock, create_embed
+
+
+class CDice(app_commands.Group):
+    def __init__(self, bot: commands.Bot):
+        super().__init__(name="cdice")
+        self.bot = bot
+
+    @app_commands.command(name="roll", description="ダイスを振ります")
+    @app_commands.checks.cooldown(1, 3)
+    async def roll(self, interaction: discord.Interaction, dices: int, upto: int):
+        try:
+            total = 0
+            if dices > 100 or upto > 10000 or dices < 1 or upto < 1:
+                raise ValueError
+            rolls = [random.randint(1, upto) for _ in range(dices)]
+        except ValueError:
+            await interaction.response.send_message(
+                embed=create_embed("エラー", "値が無効です（ダイスの数：1～100、出目：1～10000）"), ephemeral=True
+            )
+
+        rolls_concatenated = ",".join([str(i) for i in rolls])
+        total += sum(rolls)
+
+        embed = discord.Embed()
+
+        embed.color = 0x808080
+        if dices == 1:
+            embed.description = f"結果: {rolls_concatenated} -> {total}"
+        else:
+            embed.description = f"結果: {total}"
+
+        await interaction.response.send_message(embed=embed, silent=True)
+
+    @app_commands.command(name="try", description="ダイスを振り、合計が値以下で成功と判定します")
+    @app_commands.checks.cooldown(1, 3)
+    async def trying(self, interaction: discord.Interaction, dices: int, upto: int, value: int):
+        try:
+            total = 0
+            if dices > 100 or upto > 10000 or dices < 1 or upto < 1:
+                raise ValueError
+            rolls = [random.randint(1, upto) for _ in range(dices)]
+        except ValueError:
+            await interaction.response.send_message(
+                embed=create_embed("エラー", "値が無効です（ダイスの数：1～100、出目：1～10000）"), ephemeral=True
+            )
+
+        rolls_concatenated = ",".join([str(i) for i in rolls])
+        total += sum(rolls)
+
+        embed = discord.Embed()
+
+        if dices == 1:
+            if total <= value:
+                embed.color = 0x456cba
+                embed.description = f"結果: {total} <= {value} 成功！"
+            else:
+                embed.color = 0xba4545
+                embed.description = f"結果: {total} > {value} 失敗"
+        else:
+            if total <= value:
+                embed.color = 0x456cba
+                embed.description = f"結果: {rolls_concatenated} -> {total} <= {value} 成功！"
+            else:
+                embed.color = 0xba4545
+                embed.description = f"結果: {rolls_concatenated} -> {total} > {value} 失敗"
+
+        await interaction.response.send_message(embed=embed, silent=True)
+
+    async def on_error(self, interaction: discord.Interaction, error: app_commands.AppCommandError):
+       if isinstance(error, app_commands.CommandOnCooldown):
+           await interaction.response.send_message("ちょっと待って！", ephemeral=True)
+
+
+async def setup(bot: commands.Bot):
+    bot.tree.add_command(CDice(bot))

--- a/cogs/ckill.py
+++ b/cogs/ckill.py
@@ -39,6 +39,7 @@ class CKill(commands.Cog):
 
     @app_commands.command(name="ckill", description="キルコマンド(ネタ)")
     @app_commands.describe(target="キルするユーザー(任意)", count="回数(デフォルト1)")
+    @app_commands.checks.cooldown(1, 3)
     async def ckill(
         self, interaction: discord.Interaction,
         target: Optional[Member] = None,
@@ -78,6 +79,10 @@ class CKill(commands.Cog):
                 if "item.minecraft." in k and "_spawn_egg" in k
             ]
             self.items = [v for k, v in self.lang_data.items() if "item.minecraft." in k]
+
+    async def on_error(self, interaction: discord.Interaction, error: app_commands.AppCommandError):
+       if isinstance(error, app_commands.CommandOnCooldown):
+           await interaction.response.send_message("ちょっと待って！", ephemeral=True)
 
 
 async def setup(bot: commands.Bot):


### PR DESCRIPTION
# 新生ダイスコマンド
現在チャットで直接行うダイス機能をそのままに、新たに /cdice コマンドを追加しました！
## 使い方
### /cdice roll (ダイスの数) (出目)
ダイスを振ります。  
それぞれの出目、振った合計値が出力されます。

### /cdice try (ダイスの数) (出目) (値)
ダイスを振り、値以下であれば成功と判定をします**（未満→以下へ仕様変更）**。  
roll に加え、成功か失敗かが出力されます。

# レート制限
いくつかのコマンドに3秒に1回のレート制限を追加しました！
## 該当コマンド
- /ccolor random
- /cdice roll
- /cdice try
- /ckill

# 適用
config.json に /cdice についての記述を加えてください。

本番環境でなく試験版Botでのテストのみをしたので動かない場合があります。その場合はすぐさまお知らせください。