### PR TITLE
/cwarn DM拒否のエラーハンドリング

### DIFF
--- a/cogs/cwarn.py
+++ b/cogs/cwarn.py
@@ -72,7 +72,10 @@ class Cwarn(commands.Cog):
                         color=0xFF0000,
                     )
                     warn_dm_embed.set_footer(text="マイクラコマンド研究所 運営一同")
-                    await dm.send(embed=warn_dm_embed)
+                    try:
+                        await dm.send(embed=warn_dm_embed)
+                    except discord.Forbidden:
+                        await interaction.response.send_message(f"{target.mention}はDM受信を拒否しているため送信できませんでした。\nチケットを発券して、点数が増えたことを通知してください。\nなお、**点数追加の処理は既に行われています。**")
                 else:
                     return
 
@@ -111,7 +114,10 @@ class Cwarn(commands.Cog):
                         color=0xFF0000,
                     )
                     warn_dm_rem_embed.set_footer(text="マイクラコマンド研究所 運営一同")
-                    await dm.send(embed=warn_dm_rem_embed)
+                    try:
+                        await dm.send(embed=warn_dm_embed)
+                    except discord.Forbidden:
+                        await interaction.response.send_message(f"{target.mention}はDM受信を拒否しているため送信できませんでした。\nチケットを発券して、点数が削除されたことを通知してください。\nなお、**点数追加の処理は既に行われています。**")
                 else:
                     return
 


### PR DESCRIPTION
現在、/cwarnでは警告点数が追加された際、該当者にはbotからDMが送信されることで通知される。 しかしこの状態では、DM受信を拒否しているユーザーに違反点数が追加されたことを通知できず、知らぬ間に前科が増えることとなる。 最悪の場合、理由が分からないままBANされる可能性もある。
このcommitでは、DMの送信に失敗した場合コマンド実行者にその旨を通知し、別途チケットを建てて該当者に通知を促すよう仕様を追加している。