### PR TITLE
fix: サーバー作成時刻からの経過時間の表示バグを修正

### DIFF
--- a/cogs/change_status.py
+++ b/cogs/change_status.py
@@ -80,8 +80,8 @@ class ChangeStatus(commands.Cog):
                     activity = discord.Activity(type=discord.ActivityType.playing, name=name.replace("%MEMBER_COUNT%", str(len(self.bot.users))))
                 elif activity_type == "created_at":  # サーバー作成日時からの経過時間
                     created_at = self.bot.guilds[0].created_at  # 最初のサーバーの作成日時を取得
-                    elapsed_time_tick = str((datetime.now(timezone.utc) - created_at).seconds * 20).split(".")[0]
-                    elapsed_time_days = str((datetime.now(timezone.utc) - created_at).days).split(".")[0]
+                    elapsed_time_tick = str(int((datetime.now(timezone.utc) - created_at).total_seconds() * 20))
+                    elapsed_time_days = str(int((datetime.now(timezone.utc) - created_at).days))
                     activity = discord.Activity(type=discord.ActivityType.playing, name=name.replace("%CREATED_AT%", f"{elapsed_time_tick}tick(≒{elapsed_time_days}日)"))
                 elif activity_type == "server_anniversary":  # サーバー周年記念
                     created_at = self.bot.guilds[0].created_at  # 最初のサーバーの作成日時を取得


### PR DESCRIPTION
https://dev.classmethod.jp/articles/keep-in-mind-python-datetime-timedelta-seconds/
と同様の現象によって発生するバグを解消。